### PR TITLE
Added dimensionbefore to settings.  

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,14 +66,14 @@
   to: 150000,
   heterogeneity: ['50/50000'],
   step: 1000,
-  dimension: '&amp;nbsp;$'
+  dimensionbefore: '$&amp;nbsp;'
 }</pre>
     </div>
     <div class="layout-slider">
       <input id="Slider2" type="slider" name="price" value="5000;50000" />
     </div>
     <script type="text/javascript" charset="utf-8">
-      jQuery("#Slider2").slider({ from: 5000, to: 150000, heterogeneity: ['50/50000'], step: 1000, dimension: '&nbsp;$' });
+      jQuery("#Slider2").slider({ from: 5000, to: 150000, heterogeneity: ['50/50000'], step: 1000, dimensionbefore: '$&nbsp;' });
     </script>
 
     <div class="layout-slider-settings">

--- a/js/jquery.slider.js
+++ b/js/jquery.slider.js
@@ -160,7 +160,8 @@
       round: 0,
       format: { format: "#,##0.##" },
       value: "5;7",
-      dimension: ""
+      dimension: "",
+	  dimensionbefore: ""	  
     },
     
     className: "jslider",
@@ -178,10 +179,10 @@
           '<div class="<%=className%>-pointer <%=className%>-pointer-to"></div>' +
         
           '<div class="<%=className%>-label"><span><%=settings.from%></span></div>' +
-          '<div class="<%=className%>-label <%=className%>-label-to"><span><%=settings.to%></span><%=settings.dimension%></div>' +
+          '<div class="<%=className%>-label <%=className%>-label-to"><span><%= settings.dimensionbefore %><%=settings.to%><%=settings.dimension%></span></div>' +
 
-          '<div class="<%=className%>-value"><span></span><%=settings.dimension%></div>' +
-          '<div class="<%=className%>-value <%=className%>-value-to"><span></span><%=settings.dimension%></div>' +
+          '<div class="<%=className%>-value"><%=settings.dimensionbefore%><span></span><%=settings.dimension%></div>' +
+          '<div class="<%=className%>-value <%=className%>-value-to"><%=settings.dimensionbefore%><span></span><%=settings.dimension%></div>' +
           
           '<div class="<%=className%>-scale"><%=scale%></div>'+
 
@@ -230,7 +231,8 @@
       settings: {
         from: this.nice( this.settings.from ),
         to: this.nice( this.settings.to ),
-        dimension: this.settings.dimension
+        dimension: this.settings.dimension,
+		dimensionbefore: this.settings.dimensionbefore
       },
       scale: this.generateScale()
     }) );


### PR DESCRIPTION
This means you can pass in a string to appear before the value.  This is better for currencies like $ and £ that look funny after.

A better general solution might be the ability to pass in a function
that takes the value and converts it generally, but this should cover
most cases.
