### PR TITLE
Added option to disable slider labels

### DIFF
--- a/css/jslider.css
+++ b/css/jslider.css
@@ -37,4 +37,5 @@
   .jslider-single .jslider-pointer-to,
   .jslider-single .jslider-value-to,
   .jslider-single .jslider-bg .v,
-  .jslider-limitless .jslider-label { display: none; }
+  .jslider-limitless .jslider-label,
+  .jslider-labelless .jslider-value { display: none; }

--- a/js/jquery.slider.js
+++ b/js/jquery.slider.js
@@ -157,6 +157,7 @@
       step: 1,
       smooth: true,
       limits: true,
+      labels: true,
       round: 0,
       format: { format: "#,##0.##" },
       value: "5;7",
@@ -281,6 +282,9 @@
     if( !$this.settings.limits )
       this.domNode.addDependClass("limitless");
 
+    if( !$this.settings.labels )
+      this.domNode.addDependClass("labelless");
+
     this.domNode.find(OPTIONS.selector + "pointer").each(function( i ){
       var value = $this.settings.value.split(";")[i];
       if( value ){
@@ -400,7 +404,7 @@
     
     // redraw position of labels
     this.redrawLabels( pointer );
-
+    this.redrawLimits();
   };
   
   jSlider.prototype.redrawLabels = function( pointer ){
@@ -421,77 +425,79 @@
         sizes.right = false;
         
       label.o.css({ left: prc + "%", marginLeft: sizes.margin, right: "auto" });
-      if( sizes.right ) label.o.css({ left: "auto", right: 0 });
+      if( sizes.right )
+        label.o.css({ left: "auto", right: 0 });
+
       return sizes;
     }
 
-    var self = this;
-	  var label = this.o.labels[pointer.uid];
-	  var prc = pointer.value.prc;
+    if( this.settings.labels ){
+      var self = this;
+      var label = this.o.labels[pointer.uid];
+      var prc = pointer.value.prc;
 
-	  var sizes = {
-	    label: label.o.outerWidth(),
-	    right: false,
-	    border: ( prc * this.sizes.domWidth ) / 100
-	  };
+      var sizes = {
+        label: label.o.outerWidth(),
+        right: false,
+        border: ( prc * this.sizes.domWidth ) / 100
+      };
 
-    if( !this.settings.single ){
-      // glue if near;
-      var another = this.o.pointers[1-pointer.uid];
-    	var another_label = this.o.labels[another.uid];
+      if( !this.settings.single ){
+        // glue if near;
+        var another = this.o.pointers[1-pointer.uid];
+        var another_label = this.o.labels[another.uid];
 
-      switch( pointer.uid ){
-        case 0:
-          if( sizes.border+sizes.label / 2 > another_label.o.offset().left-this.sizes.domOffset.left ){
-            another_label.o.css({ visibility: "hidden" });
-        	  another_label.value.html( this.nice( another.value.origin ) );
+        switch( pointer.uid ){
+          case 0:
+            if( sizes.border+sizes.label / 2 > another_label.o.offset().left-this.sizes.domOffset.left ){
+              another_label.o.css({ visibility: "hidden" });
+              another_label.value.html( this.nice( another.value.origin ) );
 
-          	label.o.css({ visibility: "visible" });
+              label.o.css({ visibility: "visible" });
 
-          	prc = ( another.value.prc - prc ) / 2 + prc;
-          	if( another.value.prc != pointer.value.prc ){
-          	  label.value.html( this.nice(pointer.value.origin) + "&nbsp;&ndash;&nbsp;" + this.nice(another.value.origin) );
-            	sizes.label = label.o.outerWidth();
-            	sizes.border = ( prc * this.sizes.domWidth ) / 100;
+              prc = ( another.value.prc - prc ) / 2 + prc;
+              if( another.value.prc != pointer.value.prc ){
+                label.value.html( this.nice(pointer.value.origin) + "&nbsp;&ndash;&nbsp;" + this.nice(another.value.origin) );
+                sizes.label = label.o.outerWidth();
+                sizes.border = ( prc * this.sizes.domWidth ) / 100;
+              }
+            } else {
+              another_label.o.css({ visibility: "visible" });
             }
-          } else {
-          	another_label.o.css({ visibility: "visible" });
-          }
-          break;
+            break;
 
-        case 1:
-          if( sizes.border - sizes.label / 2 < another_label.o.offset().left - this.sizes.domOffset.left + another_label.o.outerWidth() ){
-            another_label.o.css({ visibility: "hidden" });
-        	  another_label.value.html( this.nice(another.value.origin) );
+          case 1:
+            if( sizes.border - sizes.label / 2 < another_label.o.offset().left - this.sizes.domOffset.left + another_label.o.outerWidth() ){
+              another_label.o.css({ visibility: "hidden" });
+              another_label.value.html( this.nice(another.value.origin) );
 
-          	label.o.css({ visibility: "visible" });
+              label.o.css({ visibility: "visible" });
 
-          	prc = ( prc - another.value.prc ) / 2 + another.value.prc;
-          	if( another.value.prc != pointer.value.prc ){
-          	  label.value.html( this.nice(another.value.origin) + "&nbsp;&ndash;&nbsp;" + this.nice(pointer.value.origin) );
-            	sizes.label = label.o.outerWidth();
-            	sizes.border = ( prc * this.sizes.domWidth ) / 100;
+              prc = ( prc - another.value.prc ) / 2 + another.value.prc;
+              if( another.value.prc != pointer.value.prc ){
+                label.value.html( this.nice(another.value.origin) + "&nbsp;&ndash;&nbsp;" + this.nice(pointer.value.origin) );
+                sizes.label = label.o.outerWidth();
+                sizes.border = ( prc * this.sizes.domWidth ) / 100;
+              }
+            } else {
+              another_label.o.css({ visibility: "visible" });
             }
-          } else {
-            another_label.o.css({ visibility: "visible" });
-          }
-          break;
+            break;
+        }
+      }
+
+      sizes = setPosition( label, sizes, prc );
+      
+      /* draw second label */
+      if( another_label ){
+        var sizes = {
+          label: another_label.o.outerWidth(),
+          right: false,
+          border: ( another.value.prc * this.sizes.domWidth ) / 100
+        };
+        sizes = setPosition( another_label, sizes, another.value.prc );
       }
     }
-
-    sizes = setPosition( label, sizes, prc );
-    
-    /* draw second label */
-    if( another_label ){
-      var sizes = {
-  	    label: another_label.o.outerWidth(),
-  	    right: false,
-  	    border: ( another.value.prc * this.sizes.domWidth ) / 100
-  	  };
-      sizes = setPosition( another_label, sizes, another.value.prc );
-    }
-	  
-    this.redrawLimits();
   };
   
   jSlider.prototype.redrawLimits = function(){


### PR DESCRIPTION
I added a new option to disable the text-labels above the slider handles/pointers.

``` javascript
$('#myslider').slider({
  labels: false
});
```

This also fixes issues #21 and partly #8.
